### PR TITLE
Added an MDAnalysis version check to run_steric_resolution.py

### DIFF
--- a/docker_build/run_steric_resolution.py
+++ b/docker_build/run_steric_resolution.py
@@ -14,6 +14,7 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot
 import os
+assert int(MDAnalysis.__version__.split('.')[1]) > 14, "MDAnalysis version must be > 0.14."
 
 def cleanup_files(output_path):
     for filepath in glob.glob(output_path + '/*'):


### PR DESCRIPTION
PR that adds a check to ensure we are using the dev branch of MDA (needed for proper writing of residue numbers in large `.gro` files).
