### PR TITLE
GROMACS version / memory Issue #19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 
 before_install:
   - sudo apt-get update
-  - sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" install docker-engine=1.10.3-0~trusty
+  - sudo DEBIAN_FRONTEND=noninteractive apt-get --force-yes -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" install docker-engine=1.10.3-0~trusty
 
 install:
   - docker build -t tylerreddy/steric-conflict-resolution docker_build/

--- a/docker_build/Dockerfile
+++ b/docker_build/Dockerfile
@@ -5,9 +5,8 @@ RUN apt-get update && apt-get install -y \
 	cmake
 
 #Download and build / install GROMACS:
-# need the release-2016 branch to handle lambda-growth mdrun of massive systems
-RUN wget https://github.com/gromacs/gromacs/archive/release-2016.zip
-RUN unzip release-2016.zip && cd gromacs-release-2016 && mkdir build && cd build && cmake .. -DGMX_BUILD_OWN_FFTW=ON -DREGRESSIONTEST_DOWNLOAD=ON && make && make check && sudo make install && rm -r /gromacs-5.1.2 && rm /gromacs-5.1.2.tar.gz
+# need the specific fixes from Berk Hess to handle lambda-growth mdrun of massive systems (not available in release-2016 branch yet)
+RUN git clone https://github.com/gromacs/gromacs.git && cd gromacs && git fetch https://gerrit.gromacs.org/gromacs refs/changes/05/6105/1 && git checkout FETCH_HEAD && mkdir build && cd build && cmake .. -DGMX_BUILD_OWN_FFTW=ON -DREGRESSIONTEST_DOWNLOAD=ON && make && make check && sudo make install && rm -r /gromacs
 RUN echo "source /usr/local/gromacs/bin/GMXRC" >> ~/.bashrc
 ADD *py /steric_conflict_resolution/
 ADD test_data /steric_conflict_resolution_work/test_data

--- a/docker_build/Dockerfile
+++ b/docker_build/Dockerfile
@@ -5,8 +5,9 @@ RUN apt-get update && apt-get install -y \
 	cmake
 
 #Download and build / install GROMACS:
-RUN wget ftp://ftp.gromacs.org/pub/gromacs/gromacs-5.1.2.tar.gz
-RUN tar xfz gromacs-5.1.2.tar.gz && cd gromacs-5.1.2 && mkdir build && cd build && cmake .. -DGMX_BUILD_OWN_FFTW=ON -DREGRESSIONTEST_DOWNLOAD=ON && make && make check && sudo make install && rm -r /gromacs-5.1.2 && rm /gromacs-5.1.2.tar.gz
+# need the release-2016 branch to handle lambda-growth mdrun of massive systems
+RUN wget https://github.com/gromacs/gromacs/archive/release-2016.zip
+RUN unzip release-2016.zip && cd gromacs-release-2016 && mkdir build && cd build && cmake .. -DGMX_BUILD_OWN_FFTW=ON -DREGRESSIONTEST_DOWNLOAD=ON && make && make check && sudo make install && rm -r /gromacs-5.1.2 && rm /gromacs-5.1.2.tar.gz
 RUN echo "source /usr/local/gromacs/bin/GMXRC" >> ~/.bashrc
 ADD *py /steric_conflict_resolution/
 ADD test_data /steric_conflict_resolution_work/test_data


### PR DESCRIPTION
This PR attempts to pull in and compile a version of GROMACS that incorporates the recent [changes](https://gerrit.gromacs.org/#/c/6105/) Berk Hess made to deal with the problem in Issue #19. Note that at the time of writing those changes haven't yet been merged into the `release-2016` branch of GROMACS, so I'm using the git commands for the revision provided by the gerrit tool.
